### PR TITLE
Make final message nicer

### DIFF
--- a/pkg/config/theme.go
+++ b/pkg/config/theme.go
@@ -39,6 +39,7 @@ type colors struct {
 	Minor            lipgloss.Color
 	Patch            lipgloss.Color
 	ActiveBackground lipgloss.Color
+	Success          lipgloss.Color
 }
 
 var Theme = colors{
@@ -48,4 +49,5 @@ var Theme = colors{
 	Minor:            colorsValues["Peach"],
 	Patch:            colorsValues["Green"],
 	ActiveBackground: colorsValues["Surface1"],
+	Success:          colorsValues["Green"],
 }

--- a/pkg/update/styles.go
+++ b/pkg/update/styles.go
@@ -1,0 +1,14 @@
+package update
+
+import (
+	"updep/pkg/config"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+var (
+	checkMarkStyle = lipgloss.NewStyle().Foreground(config.Theme.Success)
+	majorDiffStyle = lipgloss.NewStyle().Foreground(config.Theme.Major)
+	minorDiffStyle = lipgloss.NewStyle().Foreground(config.Theme.Minor)
+	patchDiffStyle = lipgloss.NewStyle().Foreground(config.Theme.Patch)
+)

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -2,10 +2,12 @@ package update
 
 import (
 	"fmt"
+	"strings"
 
 	"updep/pkg/config"
-	packagemanager "updep/pkg/packageManager"
 	"updep/pkg/dependency"
+	packagemanager "updep/pkg/packageManager"
+	"updep/pkg/version"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
@@ -13,11 +15,12 @@ import (
 )
 
 type Update struct {
-	spinner   spinner.Model
-	labelText string
-	Dependencies  []dependency.Dependency
-	Pm        packagemanager.PackageManager
-	output    []byte
+	spinner      spinner.Model
+	labelText    string
+	Dependencies []dependency.Dependency
+	Pm           packagemanager.PackageManager
+	output       []byte
+	isDone       bool
 }
 
 func New() *Update {
@@ -27,7 +30,8 @@ func New() *Update {
 
 	return &Update{
 		spinner:   s,
-		labelText: "Getting outdated packages",
+		labelText: "Updating packages",
+		isDone:    false,
 	}
 }
 
@@ -52,12 +56,29 @@ func (u Update) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (u Update) View() string {
-	if u.output != nil {
-		return fmt.Sprintf(
-			"%s\n\n✓ Updated 3 packages: lodash, react, typescript",
-			u.output,
-		)
+	if !u.isDone {
+		return fmt.Sprintf("%v %s", u.spinner.View(), u.labelText)
 	}
 
-	return fmt.Sprintf("%v %s", u.spinner.View(), u.labelText)
+	var depNames []string
+	for _, d := range u.Dependencies {
+		var depStyle lipgloss.Style
+
+		switch d.DiffLevel() {
+		case version.Major:
+			depStyle = majorDiffStyle
+		case version.Minor:
+			depStyle = minorDiffStyle
+		case version.Patch:
+			depStyle = patchDiffStyle
+		}
+		depNames = append(depNames, depStyle.Render(d.Name))
+	}
+
+	return fmt.Sprintf(
+		"\n\n%v Updated %d packages: %v",
+		checkMarkStyle.Render("✓"),
+		len(u.Dependencies),
+		strings.Join(depNames, ", "),
+	)
 }


### PR DESCRIPTION
This pull request updates the package update UI to provide clearer and more visually distinct feedback when dependencies are updated. It introduces new color styling for different update types, adds a success color to the theme, and improves the summary output to show which packages were updated and their update levels.

**Theme and styling improvements:**

* Added a new `Success` color to the `colors` struct and set it to use the "Green" color in `pkg/config/theme.go`. [[1]](diffhunk://#diff-15c32344180b84517ce25d10ac50c5b1c29f3785a01d3e1fc40804f4d9021224R42) [[2]](diffhunk://#diff-15c32344180b84517ce25d10ac50c5b1c29f3785a01d3e1fc40804f4d9021224R52)
* Created new styles in `pkg/update/styles.go` for check marks and for major, minor, and patch update levels, each using the appropriate theme color.

**UI and output enhancements:**

* Updated the `Update` struct and logic in `pkg/update/update.go` to track completion state and display a styled summary of updated packages, including colored package names based on update level and a colored check mark for success. [[1]](diffhunk://#diff-ed4926b7af58aed7d2ee9652baaf60c8afd8a91ad43d0d9a964dbd26e775a062R23) [[2]](diffhunk://#diff-ed4926b7af58aed7d2ee9652baaf60c8afd8a91ad43d0d9a964dbd26e775a062L30-R34) [[3]](diffhunk://#diff-ed4926b7af58aed7d2ee9652baaf60c8afd8a91ad43d0d9a964dbd26e775a062L55-R83)
* Improved imports and dependency management in `pkg/update/update.go` to support new styling and version diff logic.